### PR TITLE
add increment and refresh buttons for increment; add activity selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,6 +61,17 @@
 
         <div class="posture" id="posture-99" onclick="selectP(99)"><p>Choose for me at random!</p></div>
       </div>
+    
+    </div>
+
+    <div id="activity-container">
+      <h2>Select an Activity</h2>
+      
+      <div id="activity-buttons">
+        <div class="activity" id="activity-0" onclick="selectActivity(0)"><p>Show Dialogue</p></div>
+        <div class="activity" id="activity-1" onclick="selectActivity(1)"><p>Increment</p></div>
+        <div class="activity" id="activity-99" onclick="selectActivity(99)"><p>Choose for me at random!</p></div>
+      </div>
     </div>
 
   </div>
@@ -79,6 +90,7 @@
       <div id="question-container">
         <p id="selection-text"></p>
         <div id="show-dialogue-container"></div>
+        <div id="increment-container"></div>
       </div>
       
     </div>

--- a/trainer.css
+++ b/trainer.css
@@ -10,6 +10,10 @@
   --purple-mid: #C1C9FC;
   --purple-light: #F2F3FE;
 
+  --blue-dark: #85C6DA;
+  --blue-mid: #ACD8E6;
+  --blue-light: #E7F4F8;
+
   --pink: #FCC1C9;
   --pink-light: #FDE8EA;
   --white: white;
@@ -66,6 +70,42 @@ body {
   padding-top: 8px;
   /* overflow-y: hidden; */
 }
+.activity {
+  height: 20px;
+  border-radius: 16px;
+  margin: 10px 5px;
+  padding: 8px 10px;
+  border: 2px solid;
+  background-color: var(--blue-mid);
+  white-space: nowrap;
+}
+.activity:hover {
+  cursor: pointer;
+  background-color: var(--blue-dark);
+}
+.activity p {
+  margin:0px;
+}
+#activity-buttons {
+  display: flex;
+  /* flex-direction: row; */
+  background-color: var(--blue-light);
+  margin: 10px;
+  border-radius: 15px;
+  height: 80px;
+  width: 880px;
+  overflow-x: scroll;
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 8px;
+  /* overflow-y: hidden; */
+}
+
+
+
+
+
+
 
 #question-description-container {
   /* border-radius: 0px 15px 15px 0px;
@@ -100,5 +140,8 @@ body {
 
 
 #show-dialogue-container {
+  text-align: left;
+}
+#increment-container p {
   text-align: left;
 }

--- a/trainer.js
+++ b/trainer.js
@@ -3,12 +3,30 @@ class Trainer {
     constructor() {
         // 100 denotes not selected, 99 denotes random 
         this.selectedPosture = 100;
+        this.selectedActivity = 100;
+
+        // for specific activities
+        this.incrementIndex = 0;
     };
 
     setSelectedPosture(postureIndex) {
         // come back and update this random later
-        const selectedPosture = postureIndex != 99 ? postureIndex : Math.floor(Math.random() * 3);
+        const selectedPosture = postureIndex != 99 ? postureIndex : Math.floor(Math.random() * 27);
         this.selectedPosture = selectedPosture;
+    };
+
+    setSelectedActivity(activityIndex) {
+        // come back and update this random later
+        const selectedActivity = activityIndex != 99 ? activityIndex : Math.floor(Math.random() * 2);
+        this.selectedActivity = selectedActivity;
+    };
+
+    // for specific activities 
+    increment() {
+        this.incrementIndex += 1;
+    };
+    refresh() {
+        this.incrementIndex = 0;
     };
 
 };
@@ -17,18 +35,47 @@ class Trainer {
 //
 const trainer = new Trainer();
 
-// select posture, activity, or stress 
+// select posture, activity, or strategy 
 //
 function selectPosture(postureIndex) {
     trainer.setSelectedPosture(postureIndex);
     renderPractice();
 };
+function selectActivity(activityIndex) {
+    trainer.setSelectedActivity(activityIndex);
+    renderPractice();
+};
+
+// for specific activities 
+function incrementClick() {
+    // if you ever store selected posture num lines (or calculate it) can do check here 
+    trainer.increment();
+    renderPractice();
+};
+function refreshClick() {
+    trainer.refresh();
+    renderPractice();
+};
+
+
+
+function clearPractice() {
+    // clears practice section
+    document.getElementById("show-dialogue-container").innerHTML = ""; 
+    document.getElementById("increment-container").innerHTML = ""; 
+};
+
 
 // render activity based on selected posture and activity
 //
 function renderPractice() {
+    clearPractice();
     if (trainer.selectedPosture != 100) {
-        showDialogue(trainer.selectedPosture);
+        if (trainer.selectedActivity == 0) {
+            showDialogue(trainer.selectedPosture);
+        } else if (trainer.selectedActivity == 1) {
+            increment(trainer.selectedPosture);
+        }
     };
 };
 
@@ -40,6 +87,63 @@ function showDialogue(postureIndex) {
         dialogue += "<b>" + (i < 9 ? "&nbsp;" : "") + (i + 1).toString() + ".&nbsp;&nbsp;</b>" + content[postureIndex]["postureContent"]["lines"][i] + "<br>";
     }
     document.getElementById("show-dialogue-container").innerHTML = "<p>" + dialogue + "</p>";    
+};
+
+// for Activity 1, Increment
+//
+// if you click away to another activity and come back, you'll still be on your current increment
+function increment(postureIndex) {
+    let dialogue = "";
+    let endIndex = trainer.incrementIndex;
+    let incrementButtonsContainer = `
+    <div
+        id="increment-buttons-container"
+        style="
+            display: flex;
+            background-color: #D8E6AC;
+            margin: 10px;
+            border-radius: 15px;
+            height: 64px;
+            width: 200px;
+            padding-left: 8px;
+            padding-right: 8px;
+            padding-top: 6px;"
+    >
+        <div 
+            onclick="incrementClick()"
+            id="increment-button"
+            style="height: 20px;
+                border-radius: 16px;
+                margin: 10px 5px;
+                padding: 8px 10px;
+                width: 80px;
+                border: 2px solid;
+                background-color: #ABC84A;
+            "
+        >
+            <p style="margin:-2px; font-size:16px;">Increment</p>
+        </div>
+        <div 
+            onclick="refreshClick()"
+            id="increment-button"
+            style="height: 20px;
+                border-radius: 16px;
+                margin: 10px 5px;
+                padding: 8px 10px;
+                width: 60px;
+                border: 2px solid;
+                background-color: #ABC84A;
+            "
+        >
+            <p style="margin:-2px; font-size:16px;">Refresh</p>
+        </div>
+    </div>
+    `;
+    for (let i = 0; i < Math.min(endIndex + 1, content[postureIndex]["postureNumLines"]); i++) {
+        dialogue += "<b>" + (i < 9 ? "&nbsp;" : "") + (i + 1).toString() + ".&nbsp;&nbsp;</b>" + content[postureIndex]["postureContent"]["lines"][i] + "<br>";
+    }
+    document.getElementById("increment-container").innerHTML = 
+        incrementButtonsContainer + "<p>" + dialogue + "</p>";    
 };
 
 


### PR DESCRIPTION
This PR:
- adds activity selection
- adds increment and refresh buttons for Increment activity
<img width="1076" alt="increment" src="https://github.com/hannvia/dialogue-trainer/assets/134893453/53be3cf9-5be9-480d-a429-2ea98ec43ac7">

`incrementIndex` is kept as a property in the `Trainer` class.  It is initialized always to 0 regardless of whether the Increment activity is selected.  It is incremented every time the increment button is clicked.  When the refresh button is clicked, it is set back to 0. 

Notes:
- increment and refresh buttons are currently styled inline, which is messier and means no hover
- increment level is retained upon return to Increment activity even if another activity is selected in the interim 