### PR TITLE
Add strategy content and logic; improve visual layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,8 +117,9 @@
   <div id="strategy-container">
     <h2>Strategies for Learning</h2>
     <p>
-      Techniques for memorization, feel free to sample and see what works for you. <br>
-      When you have selected via one of the orange buttons below, your strategy will show up here.
+      Techniques for memorization, drawn from educational pedagogy and cognitive science. 
+      <br> Feel free to sample and see what works for you. 
+      <br> When you have selected via one of the orange or purple buttons below, your strategy will show up here.
     </p>
 
     <div id="strategy-content">
@@ -128,13 +129,16 @@
     </div>
 
     <div class="strategy-options-container" id="strategy-buttons">
-      <div class="strategy-option strategy" id="strategy-0" onclick="selectStrategy(0)"><p></p></div>
-      <div class="strategy-option strategy" id="strategy-1" onclick="selectStrategy(1)"><p></p></div>
-      <div class="strategy-option strategy" id="strategy-2" onclick="selectStrategy(2)"><p></p></div>
-      <div class="strategy-option strategy" id="strategy-3" onclick="selectStrategy(3)"><p></p></div>
-      <div class="strategy-option strategy" id="strategy-4" onclick="selectStrategy(4)"><p></p></div>
-      <div class="strategy-option strategy" id="strategy-5" onclick="selectStrategy(5)"><p></p></div>
-      <div class="strategy-option strategy" id="strategy-6" onclick="selectStrategy(6)"><p></p></div>
+      <div class="strategy-option color-0" id="strategy-0" onclick="selectStrategy(0)"><p></p></div>
+      <div class="strategy-option color-1" id="strategy-1" onclick="selectStrategy(1)"><p></p></div>
+      <div class="strategy-option color-0" id="strategy-2" onclick="selectStrategy(2)"><p></p></div>
+      <div class="strategy-option color-1" id="strategy-3" onclick="selectStrategy(3)"><p></p></div>
+      <div class="strategy-option color-0" id="strategy-4" onclick="selectStrategy(4)"><p></p></div>
+      <div class="strategy-option color-1" id="strategy-5" onclick="selectStrategy(5)"><p></p></div>
+      <div class="strategy-option color-0" id="strategy-6" onclick="selectStrategy(6)"><p></p></div>
+      <div class="strategy-option color-1" id="strategy-7" onclick="selectStrategy(7)"><p></p></div>
+      <div class="strategy-option color-0" id="strategy-8" onclick="selectStrategy(8)"><p></p></div>
+      <div class="strategy-option color-1" id="strategy-9" onclick="selectStrategy(9)"><p></p></div>
     </div>
 
   </div>

--- a/index.html
+++ b/index.html
@@ -116,16 +116,15 @@
 
   <div id="strategy-container">
     <h2>Strategies for Learning</h2>
-    <p>Techniques for memorization, feel free to sample and see what works for you</p>
+    <p>
+      Techniques for memorization, feel free to sample and see what works for you. <br>
+      When you have selected via one of the orange buttons below, your strategy will show up here.
+    </p>
 
     <div id="strategy-content">
-
-      <div id="strategy-text-container">
-        
+      <div id="strategy-text-container">        
         <div id="strategy-text"></div>
-
-      </div>
-      
+      </div>     
     </div>
 
     <div class="strategy-options-container" id="strategy-buttons">

--- a/index.html
+++ b/index.html
@@ -116,7 +116,17 @@
 
   <div id="strategy-container">
     <h2>Strategies for Learning</h2>
-    <p>Techniques for memorization, try them out and see what works for you</p>
+    <p>Techniques for memorization, feel free to sample and see what works for you</p>
+
+    <div id="strategy-content">
+
+      <div id="strategy-text-container">
+        
+        <div id="strategy-text"></div>
+
+      </div>
+      
+    </div>
 
     <div class="strategy-options-container" id="strategy-buttons">
       <div class="strategy-option strategy" id="strategy-0" onclick="selectStrategy(0)"><p></p></div>
@@ -126,14 +136,6 @@
       <div class="strategy-option strategy" id="strategy-4" onclick="selectStrategy(4)"><p></p></div>
       <div class="strategy-option strategy" id="strategy-5" onclick="selectStrategy(5)"><p></p></div>
       <div class="strategy-option strategy" id="strategy-6" onclick="selectStrategy(6)"><p></p></div>
-    </div>
-
-    <div id="strategy-content">
-
-      <div id="strategy-text-container">
-        <div id="strategy-text"></div>
-      </div>
-      
     </div>
 
   </div>

--- a/trainer.css
+++ b/trainer.css
@@ -112,6 +112,7 @@ body {
   padding: 8px;
   margin-top: 15px;
   width: 880px;
+  height: 150px;
   font-size: 18px;
   line-height: 1.4em;
 }
@@ -130,20 +131,25 @@ body {
 
 .strategy-options-container {
   display: flex;
-  margin: 10px;
   border-radius: 15px;
-  height: 40px;
+  height: 42px;
   width: 240px;
-  padding-left: 8px;
+  justify-content: space-between;
+  margin: 4px;
+  /* padding-left: 8px;
   padding-right: 8px;
-  padding-top: 8px;
+  padding-top: 8px; */ 
+  
+  /* border: 2px solid; */
 }
 
 .strategy-option {
   height: 10px;
   border-radius: 9px;
-  margin: 10px 5px;
-  padding: 4px 9px;
+  padding: 2px 7px;
+  margin-top: 12px;
+  /* margin: 10px 5px;
+  padding: 4px 9px; */
   border: 2px solid;
   white-space: nowrap;
   background-color: var(--orange-mid);

--- a/trainer.css
+++ b/trainer.css
@@ -112,7 +112,7 @@ body {
   padding: 8px;
   margin-top: 15px;
   width: 880px;
-  height: 150px;
+  min-height: 150px;
   font-size: 18px;
   line-height: 1.4em;
 }
@@ -184,6 +184,7 @@ body {
   padding: 8px;
   margin-top: 15px;
   width: 880px;
+  min-height: 150px;
   font-size: 18px;
   line-height: 1.4em;
 }

--- a/trainer.css
+++ b/trainer.css
@@ -2,6 +2,7 @@
   --teal-dark: #2F4F4F;
 
   --aquamarine: #ACE6D7;
+  --aquamarine-light: #DDF5EF;
   --aquamarine-tint: #F6FCFB;
 
   --yellow: #FCF4C1;
@@ -28,7 +29,7 @@
   --orange-tint: #FFD6B3;
 }
 
-#title, #credits {
+#title {
   background-color: var(--aquamarine);
   border-radius: 15px;
 }
@@ -51,7 +52,7 @@ body {
 .option {
   height: 20px;
   border-radius: 16px;
-  margin: 10px 5px;
+  margin: 8px 5px;
   padding: 8px 10px;
   border: 2px solid;
   white-space: nowrap;
@@ -107,7 +108,7 @@ body {
 
 
 #strategy-text-container {
-  background-color: var(--orange-tint);
+  background-color: var(--aquamarine-light);
   border-radius: 15px;
   padding: 8px;
   margin-top: 15px;
@@ -123,7 +124,7 @@ body {
   justify-content: center;
 }
 #strategy-container {
-  background-color: var(--orange-light);
+  background-color: var(--aquamarine);
   border-radius: 15px;
   padding: 15px;
   margin-top: 15px;
@@ -133,7 +134,7 @@ body {
   display: flex;
   border-radius: 15px;
   height: 42px;
-  width: 240px;
+  width: 300px;
   justify-content: space-between;
   margin: 4px;
   /* padding-left: 8px;
@@ -152,14 +153,24 @@ body {
   padding: 4px 9px; */
   border: 2px solid;
   white-space: nowrap;
-  background-color: var(--orange-mid);
 }
 .strategy-option:hover {
   cursor: pointer;
-  background-color: var(--orange-dark);
 }
 .strategy-option p {
   margin:0px;
+}
+.color-0 {
+  background-color: var(--orange-mid);
+}
+.color-0:hover{
+  background-color: var(--orange-dark);
+}
+.color-1 {
+  background-color: var(--purple-mid);
+}
+.color-1:hover{
+  background-color: var(--purple-dark);
 }
 
 

--- a/trainer.js
+++ b/trainer.js
@@ -273,13 +273,94 @@ const activityMap = {
     },
 };
 const strategyMap = {
-    0: "Strategy 0",
-    1: "Strategy 1",
-    2: "Strategy 2",
-    3: "Strategy 3",
-    4: "Strategy 4",
-    5: "Strategy 5",
-    6: "Strategy 6",
+    0: "<b> BREAK IT DOWN </b><br> \
+        <br> When we are approaching a large goal, tackling it all at once can seem insurmountable. \
+        <br> Therefore, to make the process more manageable, we can break it down. \
+        <br> If it feels daunting to learn all 27 lines of Standing Head to Knee, how about just one line? \
+        <br> Start with just the first line.  Repeat until you know it. \
+        <br> Then, work on just the second line.  Repeat until you know it. \
+        <br> Add the second line on to the first, and repeat both lines until you are comfortable. \
+        <br> Continue with the third line, fourth, and so on. \
+        <br> By doing a little at a time, we can slowly add on to what we know, \
+        <br> and ensure that we know it well.",
+    1: "<b> FREQUENCY OVER INTENSITY </b><br> \
+        <br> To learn the dialogue well, we must practice it a lot. \
+        <br> By maintaining a moderate intensity every session, we can increase the frequency of our sessions. \
+        <br> In other words, doing a little bit regularly will add up to a lot in the end. \
+        <br> There is value in building consistency through managing expectations: \
+        <br> a little progress every time will add up over enough times.",
+    2: "<b> WRITE IT DOWN </b><br> \
+        <br> When you are first learning the dialogue, try writing the dialogue for the entire posture down on paper, \
+        <br> each line, one line at a time, one line after the other. \
+        <br> Writing the content down helps you process and absorb it in a cognitive manner. \
+        <br> Writing the words down in your own handwriting also helps subconsciously signal to your brain \
+        <br> that this information is something you believe in.",
+    3: "<b> WRITE TO TEST </b><br> \
+        <br> On a clean sheet of paper, \
+        <br> write down the dialogue for a posture from memory. \
+        <br> This will force you to be detail-oriented and to process the information in order, \
+        <br> one line at a time, one word at a time. \
+        <br> When you are done, compare your regurgitation to the actual dialogue. \
+        <br> If there are any words or lines you missed, add them in. \
+        <br> If there are any words you got wrong, cross them out and correct them. \
+        <br> By physically overwriting the words on the page, you are rewriting the correct information into your brain. ",
+    4: "<b> COMBINE LEARNING WITH MOVEMENT </b><br> \
+        <br> If it is difficult to learn while sitting still, try learning while in motion. \
+        <br> Language professor John Rassias found that students learned new vocabulary words more quickly \
+        <br> when they threw and caught a ball while being introduced to the word. \
+        <br> So when learning the dialogue, try doing a physical movement with every new phrase or line you learn. \
+        <br> For example, pacing around the room, making your bed, folding the laundry. \
+        <br> Any physical motion that is repetitive, familiar, and so ingrained in your subconscious \
+        <br> that you can do it without thinking - using your thinking energy for the new information. \
+        <br> By activating two cognitive processes simultaneously - kinesthetic and intellectual - \
+        <br> you can ingrain the information more solidly.",
+    5: "<b> CONNECT NEW TO KNOWN </b><br> \
+        <br> To internalize a new piece of information, we can connect it to something we already know. \
+        <br> We already know the physical steps of each posture very well. \
+        <br> We can do it on our own without anyone telling us. \
+        <br> Every time you learn a new line, say it out loud while doing the motion physically. \
+        <br> Thereby tying each new verbal command to a physical movement that you already know. \
+        <br> This way, when we are reciting, we can internally anchor from what we already know - \
+        <br> the physical sequence - and recall the description words from there.",
+        // We can broaden our understanding by expanding what we know. \
+    6: "<b> CREATE MEANINGFUL UNDERSTANDING </b></br> \
+        </br> One way to create deep, lasting learning is through forming connections. \
+        </br> Connections between ourselves, our past experiences, and our worldview, \
+        </br> and the content we are seeking to internalize. \
+        </br> These unique, personalized connections are our own to seek and identify. \
+        <br> It is this process of forming connections that helps us further our understanding. \
+        <br> The deeper and more meaningful the connection, the deeper and more meaningful our understanding.",
+    7: "<b> FORCE YOURSELF TO SAY IT FAST </b><br> \
+        <br> When you first have a pose memorized, you might take longer to recall certain words or phrases, \
+        <br> thereby causing pauses in your recitation. \
+        <br> After reciting the dialogue several times with these pauses, try forcing yourself to go fast. \
+        <br> You might find that you stumble, you might find that you struggle. \
+        <br> But it is through this pressure of speed that you will force yourself to recall the information more quickly, \
+        <br> And by practicing faster recall, you are ingraining a smoother transition between all the information.",
+    8: "<b> SIMULATE THE PUBLIC EYE </b><br> \
+        <br> Practicing in the privacy and psychological safety of your room is one atmosphere, \
+        <br> while practicing in the open public is another altogether. \
+        <br> Ultimately, we will be delivering the dialogue in the public eye, \
+        <br> so it can behoove us to simulate such an environment. \
+        <br> Find a space that simulates the pressure of a large crowd. \
+        <br> A long hallway, the front of a classroom, the podium of an auditorium. \
+        <br> And deliver the dialogue there. \
+        <br> If you feel nervous and pressured, you're doing it right! \
+        <br> It is through the practice of putting ourselves in these environments \
+        <br> and working through the internal emotions that ensue, \
+        <br> that we will improve at managing our emotions and finding peace in front of a real crowd.",
+    9: "<b> CONSISTENCY THROUGH SELF-CONSCIOUSNESS </b><br> \
+        <br> Have you ever known a posture well in the privacy of your own room, \
+        <br> yet stumble and blank when you recite in front of others? \
+        <br> The key difference is the self-consciousness caused by the presence (and presumed judgment) \
+        <br> of another person. \
+        <br> Therefore, practice repeatedly feeling and tolerating such self-consciousness \
+        <br> by taking the dialogue out into the world. \
+        <br> Recite while on a walk through busy streets, \
+        <br> Recite in the supermarket aisles, \
+        <br> Recite anywhere and everywhere you fear being judged. \
+        <br> After enough time, you may realize who your biggest critic actually is, \
+        <br> and how to negotiate peace within.",
     100: "",
 };
 

--- a/trainer.js
+++ b/trainer.js
@@ -30,6 +30,10 @@ class Trainer {
         this.selectedSection = sectionIndex;
     };
 
+    setSelectedStrategy(strategyIndex) {
+        this.selectedStrategy = strategyIndex;
+    };
+
     // for specific activities 
     increment() {
         this.incrementIndex += 1;
@@ -44,7 +48,7 @@ class Trainer {
 //
 const trainer = new Trainer();
 
-// select posture, activity, or strategy 
+// select posture, activity, or section
 //
 function selectPosture(postureIndex) {
     trainer.setSelectedPosture(postureIndex);
@@ -58,6 +62,7 @@ function selectSection(sectionIndex) {
     trainer.setSelectedSection(sectionIndex);
     renderPractice();
 };
+
 
 // for specific activities 
 function incrementClick() {
@@ -93,6 +98,19 @@ function clearPractice() {
     document.getElementById("show-dialogue-container").innerHTML = ""; 
     document.getElementById("increment-container").innerHTML = ""; 
 };
+
+
+// select strategy 
+function selectStrategy(strategyIndex) {
+    trainer.setSelectedStrategy(strategyIndex);
+    renderStrategy();
+};
+
+// render strategy based on selected strategy button 
+// 
+function renderStrategy() {
+    document.getElementById("strategy-text").innerHTML = "<p>" + strategyMap[trainer.selectedStrategy] + "</p>";   
+}
 
 
 // render activity based on selected posture and activity
@@ -253,6 +271,16 @@ const activityMap = {
         "name": "Unselected",
         "description": "",
     },
+};
+const strategyMap = {
+    0: "Strategy 0",
+    1: "Strategy 1",
+    2: "Strategy 2",
+    3: "Strategy 3",
+    4: "Strategy 4",
+    5: "Strategy 5",
+    6: "Strategy 6",
+    100: "",
 };
 
 

--- a/trainer.js
+++ b/trainer.js
@@ -10,6 +10,9 @@ class Trainer {
 
         // for specific activities
         this.incrementIndex = 0;
+
+        // for strategies, 100 denotes not selected 
+        this.selectedStrategy = 100;
     };
 
     setSelectedPosture(postureIndex) {


### PR DESCRIPTION
This PR
- sets up logic to display strategy when a strategy option is clicked
- adds 10 strategies, each with a title and content 
- improves visuals:
    - changes background color of strategy section to aquamarine 
    - alternate the button colors
    - remove highlighting of credits

Might change button colors later and might split each strategy into object with two parameters, `title` and `content`

<img width="1197" alt="strategy-content" src="https://github.com/hannvia/dialogue-trainer/assets/134893453/a3be5971-395e-4a0f-b35e-76e3445a34fa">
